### PR TITLE
Improve documentation and parse error messages

### DIFF
--- a/dotted/__init__.py
+++ b/dotted/__init__.py
@@ -1,6 +1,8 @@
 """
-Dotted notation parser with pattern matching.
+Dotted notation for safe nested data traversal with optional chaining,
+pattern matching, and transforms.
 
+Missing keys and attributes are handled gracefully—no KeyError or AttributeError.
 Use dotted to fetch, update, and remove data from deeply nested structures.
 
     >>> import dotted

--- a/dotted/api.py
+++ b/dotted/api.py
@@ -11,6 +11,7 @@ ANY = el.ANY
 
 
 class ParseError(Exception):
+    """Raised when dotted notation cannot be parsed."""
     pass
 
 
@@ -19,7 +20,7 @@ def _parse(ops):
     try:
         results = grammar.template.parse_string(ops, parse_all=True)
     except el.pp.ParseException as e:
-        raise ParseError(f'{e.msg} at pos {e.loc}: {repr(e.pstr)}')
+        raise ParseError(f"Invalid dotted notation: {e.msg}\n  {repr(ops)}\n  {' ' * e.loc}^") from None
     return el.Dotted(results)
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "rt") as f:
 
 setuptools.setup(
     name="dotted_notation",
-    version="0.13.3",
+    version="0.13.4",
     author="Frey Waid",
     author_email="logophage1@gmail.com",
     description="Dotted notation for safe nested data traversal with optional chaining, pattern matching, and transforms",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -267,3 +267,85 @@ def test_registry():
     assert 'float' in reg
     assert 'double' in reg  # registered above
     assert 'triple' in reg  # registered above
+
+
+# ParseError - malformed dotted notation
+
+def test_parse_error_unclosed_bracket():
+    with pytest.raises(dotted.api.ParseError) as exc:
+        dotted.get({}, 'field[')
+    assert 'Invalid dotted notation' in str(exc.value)
+
+
+def test_parse_error_unclosed_bracket_with_content():
+    with pytest.raises(dotted.api.ParseError) as exc:
+        dotted.get({}, 'field[0')
+    assert 'Invalid dotted notation' in str(exc.value)
+
+
+def test_parse_error_bracket_at_start():
+    with pytest.raises(dotted.api.ParseError) as exc:
+        dotted.get({}, '[invalid')
+    assert 'Invalid dotted notation' in str(exc.value)
+
+
+def test_parse_error_double_dot():
+    with pytest.raises(dotted.api.ParseError) as exc:
+        dotted.get({}, 'a..b')
+    assert 'Invalid dotted notation' in str(exc.value)
+
+
+def test_parse_error_trailing_dot():
+    with pytest.raises(dotted.api.ParseError) as exc:
+        dotted.get({}, 'hello.')
+    assert 'Invalid dotted notation' in str(exc.value)
+
+
+def test_parse_error_trailing_pipe():
+    with pytest.raises(dotted.api.ParseError) as exc:
+        dotted.get({}, 'hello|')
+    assert 'Invalid dotted notation' in str(exc.value)
+
+
+def test_parse_error_unclosed_regex():
+    with pytest.raises(dotted.api.ParseError) as exc:
+        dotted.get({}, '/unclosed')
+    assert 'Invalid dotted notation' in str(exc.value)
+
+
+def test_parse_error_invalid_slice():
+    with pytest.raises(dotted.api.ParseError) as exc:
+        dotted.get({}, 'field[1:2:3:4]')  # too many colons
+    assert 'Invalid dotted notation' in str(exc.value)
+
+
+def test_parse_error_empty_brackets():
+    # Empty brackets are actually valid (creates empty list)
+    # So this should NOT raise
+    result = dotted.build({}, 'items[]')
+    assert result == {'items': []}
+
+
+def test_parse_error_message_format():
+    """Verify error message includes helpful pointer to error location."""
+    with pytest.raises(dotted.api.ParseError) as exc:
+        dotted.get({}, 'a.b.[')
+    error_msg = str(exc.value)
+    assert 'Invalid dotted notation' in error_msg
+    assert "'a.b.['" in error_msg
+    assert '^' in error_msg  # caret pointing to error location
+
+
+def test_parse_error_on_update():
+    with pytest.raises(dotted.api.ParseError):
+        dotted.update({}, 'field[', 'value')
+
+
+def test_parse_error_on_remove():
+    with pytest.raises(dotted.api.ParseError):
+        dotted.remove({}, 'field[')
+
+
+def test_parse_error_on_has():
+    with pytest.raises(dotted.api.ParseError):
+        dotted.has({}, 'field[')


### PR DESCRIPTION
## Changes

### Documentation (README.md)
- Add comprehensive API documentation for missing functions:
  - `has`, `setdefault`, `pluck`, `build`, `apply`, `assemble`, `quote`
- Document all `*_multi` batch operations
- Add built-in transforms reference table with parameters
- Document custom transforms, `ANY` constant, and `ParseError`
- Fix typos and incorrect code examples throughout

### Parse Error Improvements
- Show clear "Invalid dotted notation" header
- Display input string with caret (`^`) pointing to error location
- Suppress exception chain for cleaner output

**Before:**
```
Traceback (most recent call last):
  File "...api.py", line 20, in _parse
    ...
pyparsing.exceptions.ParseException: Expected end of text...

During handling of the above exception, another exception occurred:
  ...
dotted.api.ParseError: Expected end of text at pos 0: '[invalid'
```

**After:**
```
dotted.api.ParseError: Invalid dotted notation: Expected end of text
  '[invalid'
  ^
```

### Other
- Update module docstring to mention optional chaining
- Add 13 unit tests for ParseError on malformed notation
- Bump version to 0.13.4