### PR TITLE
feat: Empty path operations, mutable() function, and mutable parameter

### DIFF
--- a/dotted/__init__.py
+++ b/dotted/__init__.py
@@ -17,6 +17,7 @@ update(obj, key, val)   Update value at dotted key
 remove(obj, key)        Remove value at dotted key
 has(obj, key)           Check if key exists
 setdefault(obj, k, v)   Set value only if key missing
+mutable(obj, key)       Check if update would mutate in place
 
 Pattern Matching
 ----------------
@@ -37,9 +38,13 @@ Append transforms with |: 'field|int', 'field|str:fmt'
 
 register(name, fn)      Register custom transform
 transform(name)         Decorator for custom transforms
+
+For full documentation including all options and flags:
+    $ pydoc dotted.api
+    or see README.md
 """
 from .api import \
-    parse, is_pattern, is_inverted, quote, ANY, \
+    parse, is_pattern, is_inverted, mutable, quote, ANY, \
     register, transform, \
     assemble, assemble_multi, \
     build, build_multi, \
@@ -64,7 +69,7 @@ __all__ = [
     # Transform
     'apply', 'apply_multi', 'register', 'transform',
     # Utility
-    'parse', 'assemble', 'assemble_multi', 'quote', 'is_pattern', 'is_inverted',
+    'parse', 'assemble', 'assemble_multi', 'quote', 'is_pattern', 'is_inverted', 'mutable',
     # Constants
     'ANY',
 ]

--- a/tests/test_empty.py
+++ b/tests/test_empty.py
@@ -1,0 +1,212 @@
+"""
+Tests for empty path operations (root access).
+"""
+import dotted
+
+
+def test_get_empty_returns_root():
+    data = {'a': 1, 'b': 2}
+    assert dotted.get(data, '') == data
+
+
+def test_get_empty_list():
+    data = [1, 2, 3]
+    assert dotted.get(data, '') == data
+
+
+def test_get_empty_primitive():
+    assert dotted.get(42, '') == 42
+    assert dotted.get('hello', '') == 'hello'
+    assert dotted.get(None, '') is None
+
+
+def test_update_empty_replaces_root():
+    data = {'a': 1}
+    result = dotted.update(data, '', {'b': 2})
+    assert result == {'b': 2}
+
+
+def test_update_empty_with_primitive():
+    data = {'a': 1}
+    result = dotted.update(data, '', 42)
+    assert result == 42
+
+
+def test_update_empty_list():
+    data = [1, 2, 3]
+    result = dotted.update(data, '', [4, 5])
+    assert result == [4, 5]
+
+
+def test_remove_empty_returns_none():
+    data = {'a': 1}
+    result = dotted.remove(data, '')
+    assert result is None
+
+
+def test_remove_empty_with_matching_value():
+    data = {'a': 1}
+    result = dotted.remove(data, '', {'a': 1})
+    assert result is None
+
+
+def test_remove_empty_with_non_matching_value():
+    data = {'a': 1}
+    result = dotted.remove(data, '', {'b': 2})
+    assert result == {'a': 1}
+
+
+def test_has_empty_returns_true():
+    assert dotted.has({'a': 1}, '') is True
+    assert dotted.has([], '') is True
+    assert dotted.has(None, '') is True
+
+
+def test_expand_empty():
+    data = {'a': 1}
+    result = dotted.expand(data, '')
+    assert result == ('',)
+
+
+def test_pluck_empty():
+    data = {'a': 1, 'b': 2}
+    result = dotted.pluck(data, '')
+    assert result == ('', {'a': 1, 'b': 2})
+
+
+def test_build_empty():
+    # Building empty path returns the object's default representation
+    # For a dict with empty path, we get None (leaf default)
+    result = dotted.build({}, '')
+    assert result is None
+
+
+def test_match_empty():
+    # Empty pattern matches empty key
+    assert dotted.match('', '') == ''
+    # Empty pattern does NOT match non-empty key (pattern is Empty, key is not)
+    assert dotted.match('', 'a') is None
+    # Non-empty pattern does NOT match empty key
+    assert dotted.match('a', '') is None
+
+
+def test_setdefault_empty_existing():
+    data = {'a': 1}
+    result = dotted.setdefault(data, '', {'b': 2})
+    # Root exists, so no change
+    assert result == {'a': 1}
+
+
+# mutable tests
+
+def test_mutable_dict():
+    assert dotted.mutable({'a': 1}, 'a') is True
+
+
+def test_mutable_empty_path():
+    # Empty path can never mutate
+    assert dotted.mutable({'a': 1}, '') is False
+
+
+def test_mutable_tuple():
+    # Tuples are immutable
+    assert dotted.mutable((1, 2), '[0]') is False
+
+
+def test_mutable_list():
+    assert dotted.mutable([1, 2], '[0]') is True
+
+
+def test_mutable_nested_immutable():
+    # Dict contains tuple - can't mutate the tuple
+    assert dotted.mutable({'a': (1, 2)}, 'a[0]') is False
+
+
+def test_mutable_nested_mutable():
+    # Dict contains dict - can mutate
+    assert dotted.mutable({'a': {'b': 1}}, 'a.b') is True
+
+
+def test_mutable_string():
+    # Strings are immutable
+    assert dotted.mutable('hello', '[0]') is False
+
+
+def test_mutable_frozenset():
+    assert dotted.mutable(frozenset([1, 2]), '') is False
+
+
+def test_mutable_missing_path():
+    # Path doesn't exist yet, but parent is mutable
+    assert dotted.mutable({'a': 1}, 'b') is True
+
+
+def test_mutable_deep_nested():
+    data = {'a': {'b': {'c': 1}}}
+    assert dotted.mutable(data, 'a.b.c') is True
+
+
+def test_mutable_namedtuple():
+    from collections import namedtuple
+    Point = namedtuple('Point', ['x', 'y'])
+    p = Point(1, 2)
+    assert dotted.mutable(p, 'x') is False
+
+
+# mutable=False parameter tests
+
+def test_update_mutable_false_prevents_mutation():
+    data = {'a': 1, 'b': 2}
+    result = dotted.update(data, 'a', 99, mutable=False)
+    assert data == {'a': 1, 'b': 2}  # Original unchanged
+    assert result == {'a': 99, 'b': 2}  # Result has update
+
+
+def test_update_mutable_true_allows_mutation():
+    data = {'a': 1, 'b': 2}
+    result = dotted.update(data, 'a', 99, mutable=True)
+    assert data == {'a': 99, 'b': 2}  # Original mutated
+    assert result == {'a': 99, 'b': 2}
+
+
+def test_update_mutable_false_nested():
+    data = {'a': {'b': 1}}
+    result = dotted.update(data, 'a.b', 99, mutable=False)
+    assert data == {'a': {'b': 1}}  # Original unchanged
+    assert result == {'a': {'b': 99}}
+
+
+def test_remove_mutable_false_prevents_mutation():
+    data = {'a': 1, 'b': 2}
+    result = dotted.remove(data, 'a', mutable=False)
+    assert data == {'a': 1, 'b': 2}  # Original unchanged
+    assert result == {'b': 2}
+
+
+def test_remove_mutable_true_allows_mutation():
+    data = {'a': 1, 'b': 2}
+    result = dotted.remove(data, 'a', mutable=True)
+    assert data == {'b': 2}  # Original mutated
+    assert result == {'b': 2}
+
+
+def test_update_multi_mutable_false():
+    data = {'a': 1, 'b': 2}
+    result = dotted.update_multi(data, [('a', 99), ('b', 88)], mutable=False)
+    assert data == {'a': 1, 'b': 2}  # Original unchanged
+    assert result == {'a': 99, 'b': 88}
+
+
+def test_remove_multi_mutable_false():
+    data = {'a': 1, 'b': 2, 'c': 3}
+    result = dotted.remove_multi(data, ['a', 'b'], mutable=False)
+    assert data == {'a': 1, 'b': 2, 'c': 3}  # Original unchanged
+    assert result == {'c': 3}
+
+
+def test_update_mutable_false_on_immutable_no_copy_needed():
+    # Tuple is already immutable, mutable=False shouldn't break anything
+    data = (1, 2, 3)
+    result = dotted.update(data, '[0]', 99, mutable=False)
+    assert data == (1, 2, 3)  # Original unchanged (it's immutable anyway)
+    assert result == (99, 2, 3)


### PR DESCRIPTION
## Summary

This PR adds three related features for better control over mutability in dotted operations.

## 1. Empty Path Operations

Empty path (`''`) now works for all operations, providing access to the root of the data structure.

```python
dotted.get(data, '')         # returns root
dotted.update(data, '', val) # returns val (non-mutating)
dotted.remove(data, '')      # returns None
```

## 2. `mutable()` Function

Check if `update(obj, key, val)` would mutate `obj` in place:

```python
dotted.mutable({'a': 1}, 'a')      # True - dict is mutable
dotted.mutable({'a': 1}, '')       # False - empty path
dotted.mutable((1, 2), '[0]')      # False - tuple is immutable
dotted.mutable([1, 2], '[0]')      # True - list is mutable
dotted.mutable({'a': (1,2)}, 'a[0]') # False - nested immutable
```

## 3. `mutable` Parameter

Use `mutable=False` on `update` and `remove` to prevent mutation:

```python
data = {'a': 1, 'b': 2}
result = dotted.update(data, 'a', 99, mutable=False)
data    # {'a': 1, 'b': 2} - unchanged
result  # {'a': 99, 'b': 2} - new copy
```

## Tests

345 tests passing (34 new tests for these features).