### PR TITLE
Fix OpGroup semantics: principled fallbacks, conjunction create-if-missing

### DIFF
--- a/dotted/grammar.py
+++ b/dotted/grammar.py
@@ -44,7 +44,8 @@ numeric_quoted = _numeric_quoted.set_parse_action(el.NumericQuoted)
 numeric_key = integer.copy().set_parse_action(el.Numeric)
 numeric_slot = ppc.number.copy().set_parse_action(el.Numeric)
 
-word = (pp.Optional(backslash) + pp.CharsNotIn(reserved)).set_parse_action(el.Word)
+# Exclude whitespace so "first )" parses as key "first", not "first "
+word = (pp.Optional(backslash) + pp.CharsNotIn(reserved + ' \t\n\r')).set_parse_action(el.Word)
 non_integer = pp.Regex(f'[-]?[0-9]+[^0-9{breserved}]+').set_parse_action(el.Word)
 nameop = name.copy().set_parse_action(el.Word)
 
@@ -168,8 +169,8 @@ op_grouped = op_group_first | op_group_and | op_group_not | op_group_or
 dotted_top_inner = path_grouped | op_grouped | keycmd | attrcmd | slotgroup_first | slotgroup | slotcmd | slotspecial | slicefilter | slicecmd | empty
 _nop_wrap = (tilde + dotted_top_inner).set_parse_action(lambda t: el.NopWrap(t[1]))
 dotted_top = _nop_wrap | dotted_top_inner
-# Resolve forward: op_seq_item can be _nop_wrap so ~(name.first) parses
-op_seq_item << (_nop_wrap | keycmd | _dot_keycmd | attrcmd | slotgroup_first | slotgroup | slotcmd | slotspecial | slicefilter | slicecmd)
+# Resolve forward: op_seq_item can be _nop_wrap so ~(name.first) parses; path_grouped for (a&b).c; op_grouped for ((a,b),c)
+op_seq_item << (_nop_wrap | path_grouped | op_grouped | keycmd | _dot_keycmd | attrcmd | slotgroup_first | slotgroup | slotcmd | slotspecial | slicefilter | slicecmd)
 
 # ~. and .~ both produce NopWrap (canonical form .~)
 _dot_nop = ((dot + tilde) | (tilde + dot)) + (path_grouped | keycmd)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     author="Frey Waid",
     author_email="logophage1@gmail.com",
     description="Dotted notation for safe nested data traversal with optional chaining, pattern matching, and transforms",
-    license="MIT license",
+    license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/freywaid/dotted",
@@ -17,7 +17,6 @@ setuptools.setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -150,16 +150,19 @@ def test_path_grouping_update_disjunction():
     d = {'a': 1, 'b': 2, 'c': 3}
     result = dotted.update(d, '(a,b)', 99)
     assert result == {'a': 99, 'b': 99, 'c': 3}
+    assert dotted.get(result, '(a,b)') == (99, 99)
 
     # Partial - only updates what exists
     d2 = {'a': 1, 'c': 3}
     result = dotted.update(d2, '(a,b)', 99)
     assert result == {'a': 99, 'c': 3}
+    assert dotted.get(result, '(a,b)') == (99,)
 
-    # None exist - no change
+    # None exist - creates last concrete path (first concrete when scanning last to first)
     d3 = {'c': 3}
     result = dotted.update(d3, '(a,b)', 99)
-    assert result == {'c': 3}
+    assert result == {'b': 99, 'c': 3}
+    assert dotted.get(result, 'b') == 99
 
 
 def test_path_grouping_update_conjunction():
@@ -168,10 +171,10 @@ def test_path_grouping_update_conjunction():
     result = dotted.update(d, '(a&b)', 99)
     assert result == {'a': 99, 'b': 99, 'c': 3}
 
-    # One missing - no update
+    # One missing - creates it (conjunction: make all branches true)
     d2 = {'a': 1, 'c': 3}
     result = dotted.update(d2, '(a&b)', 99)
-    assert result == {'a': 1, 'c': 3}
+    assert result == {'a': 99, 'b': 99, 'c': 3}
 
 
 def test_path_grouping_remove_disjunction():
@@ -179,11 +182,14 @@ def test_path_grouping_remove_disjunction():
     d = {'a': 1, 'b': 2, 'c': 3}
     result = dotted.remove(d, '(a,b)')
     assert result == {'c': 3}
+    assert dotted.has(result, 'a') is False
+    assert dotted.has(result, 'b') is False
 
     # Partial
     d2 = {'a': 1, 'c': 3}
     result = dotted.remove(d2, '(a,b)')
     assert result == {'c': 3}
+    assert dotted.has(result, 'a') is False
 
 
 def test_path_grouping_remove_conjunction():


### PR DESCRIPTION
## Summary

Fixes the fundamentally broken OpGroupFirst fallback and improves OpGroup/OpGroupAnd semantics.

### Disjunction (OpGroup / OpGroupFirst)
- **Replace hacky fallback**: The old "try updates until something mutates" logic is replaced with a principled rule: when nothing matches, update the first concrete path (scanning last to first).
- **Wildcard fallback**: When nothing matches and only wildcards remain, do nothing (no concrete path to create).
- **Nested op groups**: Add `op_grouped` to `op_seq_item` so paths like `((name&first=None).first, name.first)` parse.

### Conjunction (OpGroupAnd)
- **Create if missing**: Update all branches so the conjunction eval as true; create missing paths as needed.
- **Filter blocks**: If a filter prevents any branch from being updated, abort (no partial update).

### NOP (~)
- **Fix ~(path) propagation**: `~(name.first)` now correctly NOPs. Introduced `nop_from_unwrap` so NOP propagates when wrapping OpGroup but not when segment-level (e.g. `~a.b` updates .b).

### Grammar
- **Whitespace in word**: Exclude whitespace from word tokens so `name.first )` parses key `first` not `first `.

### Tests
- Explicit has/get checks for update/remove semantics (conjunction, disjunction, inversion, NOP).
- New tests: disjunction fallbacks, conjunction filter blocks, NOP pattern, OpGroup vs OpGroupFirst.

### README
- Document fallbacks when nothing matches.
- Conjunction create-if-missing semantics.
- Note about using match-first when updating (disjunction doesn't short-circuit).

### setup.py
- Fix deprecation: remove license classifier, use `license="MIT"`.

Made with [Cursor](https://cursor.com)